### PR TITLE
Adding print support for python 3

### DIFF
--- a/simple_camera.py
+++ b/simple_camera.py
@@ -24,7 +24,7 @@ def gstreamer_pipeline (capture_width=1280, capture_height=720, display_width=12
 
 def show_camera():
     # To flip the image, modify the flip_method parameter (0 and 2 are the most common)
-    print gstreamer_pipeline(flip_method=0)
+    print(gstreamer_pipeline(flip_method=0))
     cap = cv2.VideoCapture(gstreamer_pipeline(flip_method=0), cv2.CAP_GSTREAMER)
     if cap.isOpened():
         window_handle = cv2.namedWindow('CSI Camera', cv2.WINDOW_AUTOSIZE)
@@ -40,7 +40,7 @@ def show_camera():
         cap.release()
         cv2.destroyAllWindows()
     else:
-        print 'Unable to open camera'
+        print('Unable to open camera')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

When starting the `simple_camera.py` script, two error occurs related to python print function if using python version 3

# Status

READY | ~UNDER DEVELOPMENT~ | ~ON HOLD~

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the fix using python 3 and my Jetson Nano

**Before :**

```bash
SyntaxError: invalid syntax
hicham@ted:~/Dev/jetsonDevices/CSI-Camera$ python3 simple_camera.py 
  File "simple_camera.py", line 27
    print gstreamer_pipeline(flip_method=0)
                           ^
SyntaxError: invalid syntax
hicham@ted:~/Dev/jetsonDevices/CSI-Camera$ python3 simple_camera.py 
  File "simple_camera.py", line 43
    print 'Unable to open camera'
```

**After :** 

```bash
hicham@ted:~/Dev/jetsonDevices/CSI-Camera$ python3 simple_camera.py 
nvarguscamerasrc ! video/x-raw(memory:NVMM), width=(int)1280, height=(int)720, format=(string)NV12, framerate=(fraction)60/1 ! nvvidconv flip-method=0 ! video/x-raw, width=(int)1280, height=(int)720, format=(string)BGRx ! videoconvert ! video/x-raw, format=(string)BGR ! appsink
nvbuf_utils: Could not get EGL display connection
GST_ARGUS: Creating output stream
CONSUMER: Waiting until producer is connected...
GST_ARGUS: Available Sensor modes :
GST_ARGUS: 3264 x 2464 FR = 21.000000 fps Duration = 47619048 ; Analog Gain range min 1.000000, max 10.625000; Exposure Range min 13000, max 683709000;

GST_ARGUS: 3264 x 1848 FR = 28.000001 fps Duration = 35714284 ; Analog Gain range min 1.000000, max 10.625000; Exposure Range min 13000, max 683709000;

GST_ARGUS: 1920 x 1080 FR = 29.999999 fps Duration = 33333334 ; Analog Gain range min 1.000000, max 10.625000; Exposure Range min 13000, max 683709000;

GST_ARGUS: 1280 x 720 FR = 59.999999 fps Duration = 16666667 ; Analog Gain range min 1.000000, max 10.625000; Exposure Range min 13000, max 683709000;

GST_ARGUS: 1280 x 720 FR = 120.000005 fps Duration = 8333333 ; Analog Gain range min 1.000000, max 10.625000; Exposure Range min 13000, max 683709000;

GST_ARGUS: Running with following settings:
   Camera index = 0 
   Camera mode  = 4 
   Output Stream W = 1280 H = 720 
   seconds to Run    = 0 
   Frame Rate = 120.000005 
GST_ARGUS: PowerService: requested_clock_Hz=12096000
GST_ARGUS: Setup Complete, Starting captures for 0 seconds
GST_ARGUS: Starting repeat capture requests.
CONSUMER: Producer has connected; continuing.
GST_ARGUS: Cleaning up
CONSUMER: Done Success
GST_ARGUS: Done Success
GST_ARGUS: 
PowerServiceHwVic::cleanupResources
```


# Checklist:

[x] I have performed a self-review of my own code
[ ] I have made corresponding changes to the documentation (if applicable)
[x] I have added tests that prove my fix is effective or that my feature works
[ ] New and existing unit tests pass locally with my changes