### PR TITLE
fixed the shape of image captured by camera in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ gst-launch-1.0 nvarguscamerasrc sensor_id=0 ! nvoverlaysink
 
 # More specific - width, height and framerate are from supported video modes
 # Example also shows sensor_mode paramter to nvarguscamerasrc
-$ gst-launch-1.0 nvarguscamerasrc sensor_mode=0 ! 'video/x-raw(memory:NVMM),width=3820, height=2464, framerate=21/1, format=NV12' ! nvvidconv flip-method=0 ! 'video/x-raw,width=960, height=616' ! nvvidconv ! nvegltransform ! nveglglessink -e
+$ gst-launch-1.0 nvarguscamerasrc sensor_mode=0 ! 'video/x-raw(memory:NVMM),width=3280, height=2464, framerate=21/1, format=NV12' ! nvvidconv flip-method=0 ! 'video/x-raw,width=960, height=720' ! nvvidconv ! nvegltransform ! nveglglessink -e
 
 ```
 


### PR DESCRIPTION
Hi!

Correct me if I'm wrong, but I think you swapped the numbers in raspberry pi camera native resolution. (3820 instead of 3280) It deforms the image slightly, which is totally not a big deal, but since so many people keep this repo as a reference, I figured I might as well correct it :slightly_smiling_face: 

[reference](https://www.raspberrypi.org/documentation/hardware/camera/)