### PR TITLE
massively reduce input lag by reducing buffer size in gstreamer appsink

### DIFF
--- a/dual_camera.py
+++ b/dual_camera.py
@@ -118,7 +118,7 @@ def gstreamer_pipeline(
         "nvvidconv flip-method=%d ! "
         "video/x-raw, width=(int)%d, height=(int)%d, format=(string)BGRx ! "
         "videoconvert ! "
-        "video/x-raw, format=(string)BGR ! appsink"
+        "video/x-raw, format=(string)BGR ! appsink max-buffers=1 drop=True"
         % (
             sensor_id,
             sensor_mode,

--- a/face_detect.py
+++ b/face_detect.py
@@ -30,7 +30,7 @@ def gstreamer_pipeline(
         "nvvidconv flip-method=%d ! "
         "video/x-raw, width=(int)%d, height=(int)%d, format=(string)BGRx ! "
         "videoconvert ! "
-        "video/x-raw, format=(string)BGR ! appsink"
+        "video/x-raw, format=(string)BGR ! appsink max-buffers=1 drop=True"
         % (
             capture_width,
             capture_height,

--- a/simple_camera.cpp
+++ b/simple_camera.cpp
@@ -15,7 +15,7 @@ std::string gstreamer_pipeline (int capture_width, int capture_height, int displ
     return "nvarguscamerasrc ! video/x-raw(memory:NVMM), width=(int)" + std::to_string(capture_width) + ", height=(int)" +
            std::to_string(capture_height) + ", format=(string)NV12, framerate=(fraction)" + std::to_string(framerate) +
            "/1 ! nvvidconv flip-method=" + std::to_string(flip_method) + " ! video/x-raw, width=(int)" + std::to_string(display_width) + ", height=(int)" +
-           std::to_string(display_height) + ", format=(string)BGRx ! videoconvert ! video/x-raw, format=(string)BGR ! appsink";
+           std::to_string(display_height) + ", format=(string)BGRx ! videoconvert ! video/x-raw, format=(string)BGR ! appsink max-buffers=1 drop=True";
 }
 
 int main()

--- a/simple_camera.py
+++ b/simple_camera.py
@@ -29,7 +29,7 @@ def gstreamer_pipeline(
         "nvvidconv flip-method=%d ! "
         "video/x-raw, width=(int)%d, height=(int)%d, format=(string)BGRx ! "
         "videoconvert ! "
-        "video/x-raw, format=(string)BGR ! appsink"
+        "video/x-raw, format=(string)BGR ! appsink max-buffers=1 drop=True"
         % (
             capture_width,
             capture_height,


### PR DESCRIPTION
See https://forums.developer.nvidia.com/t/how-to-eliminate-gstreamer-camera-buffer/75608/6

<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #XX

**Description**
<!-- Add your description below. -->
Limiting buffer size and enabling gstreamer appsink to drop old frames decreases glass-to-glass lag significantly.
My Jetson Nano 4GB + Raspberry Pi V2 camera went from around half a second to no noticeable delay.

Please see https://forums.developer.nvidia.com/t/how-to-eliminate-gstreamer-camera-buffer/75608/6 for the discussion.

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
